### PR TITLE
removed homebridge CBus plugin from install script

### DIFF
--- a/code/setup.sh
+++ b/code/setup.sh
@@ -39,10 +39,6 @@ step1 ()
 	apt-get install jq
 	echo "======================================="
 	echo ""
-	echo ">> download homebridge-cbus:"
-	npm install -g homebridge-cbus
-	echo "======================================="
-	echo ""
 	echo ">> download and setup java:"
 	apt-get install openjdk-8-jre-headless -y
 	echo "======================================="


### PR DESCRIPTION
Hello Greig
I've removed the homebridge CBus plugin from the install script 
The plugins need to be installed from the homebridge node environment.